### PR TITLE
[docs]: update example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Lite version of [smart_select](https://pub.dev/packages/smart_select) package, z
 
 ## Usage
 
-For a complete usage, please see the [example](https://pub.dev/packages/chips_choice#-example-tab-).
+For a complete usage, please see the [example](https://pub.dev/packages/chips_choice/example).
 
 To read more about classes and other references used by `chips_choice`, see the [API Reference](https://pub.dev/documentation/chips_choice/latest/).
 


### PR DESCRIPTION
thank you for the package...
Also, the link to navigate to the `example` tab was not working and it has been updated in this pr